### PR TITLE
Error management

### DIFF
--- a/edgar_tool/page_fetcher.py
+++ b/edgar_tool/page_fetcher.py
@@ -23,9 +23,6 @@ def fetch_page(
     :param stop_after_n: how many times to retry the request before failing
     :return: wrapper function that takes a check method and retries the request if the page load fails
     """
-    # # Simulate an error
-    # if True:
-    #     raise PageCheckFailedError()
     @retry(
         wait=wait_fixed(uniform(min_wait_seconds, max_wait_seconds)),
         stop=stop_after_attempt(stop_after_n),

--- a/edgar_tool/page_fetcher.py
+++ b/edgar_tool/page_fetcher.py
@@ -23,7 +23,9 @@ def fetch_page(
     :param stop_after_n: how many times to retry the request before failing
     :return: wrapper function that takes a check method and retries the request if the page load fails
     """
-
+    # # Simulate an error
+    # if True:
+    #     raise PageCheckFailedError()
     @retry(
         wait=wait_fixed(uniform(min_wait_seconds, max_wait_seconds)),
         stop=stop_after_attempt(stop_after_n),

--- a/edgar_tool/text_search.py
+++ b/edgar_tool/text_search.py
@@ -495,6 +495,6 @@ class EdgarTextSearcher:
             return num_results
         except NoResultsFoundError as e:
             raise NoResultsFoundError(
-                f"\nExecution aborting due to a {e.__class__.__name_} error raised "
+                f"\nExecution aborting due to a {e.__class__.__name__} error raised "
                 f"while parsing number of results for first page at URL {url}: {e}"
             ) from e

--- a/edgar_tool/text_search.py
+++ b/edgar_tool/text_search.py
@@ -484,8 +484,8 @@ class EdgarTextSearcher:
                 f"Please verify that the search/wait/retry parameters are correct and try again.",
             )
         except PageCheckFailedError as e:
-            print(e)
-            sys.exit(1)
+            print(e) 
+            raise NoResultsFoundError("No results found on the first page.") from e
 
         # If we cannot get number of results after retries, abort
         try:
@@ -496,4 +496,4 @@ class EdgarTextSearcher:
                 f"Execution aborting due to a {e.__class__.__name__} error raised "
                 f"while parsing number of results for first page at URL {url}: {e}"
             )
-            sys.exit(1)
+            raise

--- a/edgar_tool/text_search.py
+++ b/edgar_tool/text_search.py
@@ -36,6 +36,9 @@ class EdgarTextSearcher:
         Parses the number of results found from the search results page.
         :return: Number of results found
         """
+        # Simulate an error
+        if True:
+            raise ValueError()
         num_results = int(
             self.json_response.get("hits", {}).get("total", {}).get("value", 0)
         )

--- a/edgar_tool/text_search.py
+++ b/edgar_tool/text_search.py
@@ -36,13 +36,14 @@ class EdgarTextSearcher:
         Parses the number of results found from the search results page.
         :return: Number of results found
         """
-        # Simulate an error
-        if True:
-            raise ValueError()
-        num_results = int(
-            self.json_response.get("hits", {}).get("total", {}).get("value", 0)
-        )
-        return num_results
+        try:
+            num_results = int(
+                self.json_response.get("hits", {}).get("total", {}).get("value", 0)
+            )
+            return num_results
+
+        except NoResultsFoundError as e:
+            raise NoResultsFoundError("no results to parse") from e
 
     def _compute_number_of_pages(self) -> int:
         """
@@ -481,22 +482,19 @@ class EdgarTextSearcher:
                 min_wait_seconds,
                 max_wait_seconds,
                 retries,
-            )(
-                lambda json_response: json_response.get("hits", {}).get("hits", 0) != 0,
-                f"No results found on first page at URL {url}, aborting...\n"
-                f"Please verify that the search/wait/retry parameters are correct and try again.",
-            )
+            )(lambda json_response: json_response.get("hits", {}).get("hits", 0) != 0)
         except PageCheckFailedError as e:
-            print(e) 
-            raise NoResultsFoundError("No results found on the first page.") from e
+            raise PageCheckFailedError(
+                f"\n{e}. "
+                f"Please verify that the search/wait/retry parameters are correct and try again."
+            ) from e
 
         # If we cannot get number of results after retries, abort
         try:
             num_results = self._parse_number_of_results()
             return num_results
-        except Exception as e:
-            print(
-                f"Execution aborting due to a {e.__class__.__name__} error raised "
+        except NoResultsFoundError as e:
+            raise NoResultsFoundError(
+                f"\nExecution aborting due to a {e._class.name_} error raised "
                 f"while parsing number of results for first page at URL {url}: {e}"
-            )
-            raise
+            ) from e

--- a/edgar_tool/text_search.py
+++ b/edgar_tool/text_search.py
@@ -495,6 +495,6 @@ class EdgarTextSearcher:
             return num_results
         except NoResultsFoundError as e:
             raise NoResultsFoundError(
-                f"\nExecution aborting due to a {e._class.name_} error raised "
+                f"\nExecution aborting due to a {e.__class__.__name_} error raised "
                 f"while parsing number of results for first page at URL {url}: {e}"
             ) from e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "edgar-tool"
-version = "1.2.0"
+version = "1.2.1"
 description = "Search and retrieve corporate and financial data from the United States Securities and Exchange Commission (SEC)."
 authors = ["Bellingcat"]
 license = "GNU General Public License v3 (GPLv3)"


### PR DESCRIPTION
Edited errors:

- `PageCheckFailedError` -> inherits the error message from the `_fetch_first_page_results_number` function
Simulated behaviour of the error:
```bash
  File "C:\Users\EDGAR\edgar_tool\text_search.py", line 487, in _fetch_first_page_results_number
    raise PageCheckFailedError(
edgar_tool.page_fetcher.PageCheckFailedError: 
Error for url https://efts.sec.gov/LATEST/search-index?q=Test+Search&dateRange=custom&startdt=2019-06-02&enddt=2024-05-31&page=1, with code 200. Please verify that the search/wait/retry parameters are correct and try again.
```
- `NoResultsFoundError ` -> same here from `_parse_number_of_results`
Simulated behaviour of the error:
```bash
  File "C:\Users\EDGAR\edgar_tool\text_search.py", line 500, in _fetch_first_page_results_number
    raise NoResultsFoundError(
edgar_tool.page_fetcher.NoResultsFoundError: 
Execution aborting due to a NoResultsFoundError error raised while parsing number of results for first page at URL https://efts.sec.gov/LATEST/search-index?q=Test+Search&dateRange=custom&startdt=2019-06-02&enddt=2024-05-31&page=1: no results to parse
```
