### PR TITLE
Location based search #22

### DIFF
--- a/edgar_tool/cli.py
+++ b/edgar_tool/cli.py
@@ -145,7 +145,7 @@ class SecEdgarScraperCli:
                 max_wait_seconds=max_wait,
                 retries=retries,
                 destination=output,
-                peo_in = peo_in,
+                peo_in=peo_in,
                 inc_in=inc_in
             )
         except NoResultsFoundError as e:

--- a/edgar_tool/cli.py
+++ b/edgar_tool/cli.py
@@ -7,7 +7,6 @@ from edgar_tool.constants import (
     SUPPORTED_OUTPUT_EXTENSIONS,
     TEXT_SEARCH_CATEGORY_FORM_GROUPINGS,
     TEXT_SEARCH_FILING_VS_MAPPING_CATEGORIES_MAPPING,
-    TEXT_SEARCH_LOCATIONS_MAPPING,
 )
 from edgar_tool.rss import fetch_rss_feed
 from edgar_tool.text_search import EdgarTextSearcher

--- a/edgar_tool/cli.py
+++ b/edgar_tool/cli.py
@@ -7,9 +7,11 @@ from edgar_tool.constants import (
     SUPPORTED_OUTPUT_EXTENSIONS,
     TEXT_SEARCH_CATEGORY_FORM_GROUPINGS,
     TEXT_SEARCH_FILING_VS_MAPPING_CATEGORIES_MAPPING,
+    TEXT_SEARCH_LOCATIONS_MAPPING,
 )
 from edgar_tool.rss import fetch_rss_feed
 from edgar_tool.text_search import EdgarTextSearcher
+from edgar_tool.utils import parse_location_input
 from edgar_tool.page_fetcher import NoResultsFoundError
 
 
@@ -84,6 +86,8 @@ class SecEdgarScraperCli:
         retries: int = 3,
         browser: Optional[str] = None,
         headless: Optional[bool] = None,
+        peo_in: Optional[str] = None,
+        inc_in: Optional[str] = None,
     ) -> None:
         """
         Perform a custom text search on the SEC EDGAR website and save the results to either a CSV, JSON,
@@ -101,6 +105,8 @@ class SecEdgarScraperCli:
         :param retries: How many times to retry requests before failing
         :param browser: Deprecated and not used
         :param headless: Deprecated and not used
+        :param peo_in: Search principal executive offices in a location (e.g. "NY,OH")
+        :param inc_in: Search incorporated in a location (e.g. "NY,OH")
         """
         try:
             keywords = list(keywords)
@@ -109,6 +115,8 @@ class SecEdgarScraperCli:
             min_wait = float(min_wait)
             max_wait = float(max_wait)
             retries = int(retries)
+            peo_in = parse_location_input(peo_in)
+            inc_in = parse_location_input(inc_in)
         except Exception as e:
             raise ValueError(f"Invalid argument type or format: {e}")
         _validate_text_search_args(
@@ -137,6 +145,8 @@ class SecEdgarScraperCli:
                 max_wait_seconds=max_wait,
                 retries=retries,
                 destination=output,
+                peo_in = peo_in,
+                inc_in=inc_in
             )
         except NoResultsFoundError as e:
             sys.exit(2)

--- a/edgar_tool/text_search.py
+++ b/edgar_tool/text_search.py
@@ -235,10 +235,6 @@ class EdgarTextSearcher:
         
         if entity_id:
             request_args["entityName"] = entity_id
-            
-        print(request_args)
-
-
         # Handle forms and single forms
         part_filing_form = [] if filing_form is None else TEXT_SEARCH_CATEGORY_FORM_GROUPINGS[filing_form]
         part_single_forms = [] if single_forms is None else single_forms
@@ -409,6 +405,8 @@ class EdgarTextSearcher:
                         min_wait_seconds=min_wait_seconds,
                         max_wait_seconds=max_wait_seconds,
                         retries=retries,
+                        peo_in=peo_in,
+                        inc_in=inc_in,
                     )
                 except IndexError:
                     pass
@@ -444,7 +442,6 @@ class EdgarTextSearcher:
         :param peo_in: Search principal executive offices in a location (e.g. "NY,OH")
         :param inc_in: Search incorporated in a location (e.g. "NY,OH")
         """
-
         self._generate_search_requests(
             keywords=keywords,
             entity_id=entity_id,

--- a/edgar_tool/text_search.py
+++ b/edgar_tool/text_search.py
@@ -188,6 +188,8 @@ class EdgarTextSearcher:
         start_date: date,
         end_date: date,
         page_number: int,
+        peo_in: Optional[str],
+        inc_in: Optional[str],
     ) -> str:
         """
         Generates the request arguments for the SEC website based on the given parameters.
@@ -199,6 +201,8 @@ class EdgarTextSearcher:
         :param start_date: Start date for the custom date range, defaults to 5 years ago to replicate the default behavior of the SEC website
         :param end_date: End date for the custom date range, defaults to current date in order to replicate the default behavior of the SEC website
         :param page_number: Page number to request, defaults to 1
+        :param peo_in: Search principal executive offices in a location (e.g. "NY,OH")
+        :param inc_in: Search incorporated in a location (e.g. "NY,OH")
 
         :return: URL-encoded request arguments string to concatenate to the SEC website URL
         """
@@ -220,8 +224,20 @@ class EdgarTextSearcher:
         }
 
         # Add optional parameters
+        if peo_in and inc_in:
+            raise ValueError("use only one of peo_in or inc_in, not both") ## because SEC API doesn't support
+        else:
+            if peo_in:
+                request_args["locationCodes"] = peo_in
+            if inc_in:
+                request_args["locationCodes"] = inc_in
+                request_args["locationType"] = "incorporated"
+        
         if entity_id:
             request_args["entityName"] = entity_id
+            
+        print(request_args)
+
 
         # Handle forms and single forms
         part_filing_form = [] if filing_form is None else TEXT_SEARCH_CATEGORY_FORM_GROUPINGS[filing_form]
@@ -310,6 +326,8 @@ class EdgarTextSearcher:
         min_wait_seconds: float,
         max_wait_seconds: float,
         retries: int,
+        peo_in: Optional[str],
+        inc_in: Optional[str],
     ) -> None:
         """
         Generates search requests for the given parameters and date range,
@@ -324,6 +342,8 @@ class EdgarTextSearcher:
         :param min_wait_seconds: Minimum number of seconds to wait for the request to complete
         :param max_wait_seconds: Maximum number of seconds to wait for the request to complete
         :param retries: Number of times to retry the request before failing
+        :param peo_in: Search principal executive offices in a location (e.g. "NY,OH")
+        :param inc_in: Search incorporated in a location (e.g. "NY,OH")
         """
 
         # Fetch first page, verify that the request was successful by checking the result count value on the page
@@ -335,6 +355,8 @@ class EdgarTextSearcher:
             start_date=start_date,
             end_date=end_date,
             page_number=1,
+            peo_in=peo_in,
+            inc_in=inc_in,
         )
         url = f"{TEXT_SEARCH_BASE_URL}{request_args}"
 
@@ -403,6 +425,8 @@ class EdgarTextSearcher:
         max_wait_seconds: float,
         retries: int,
         destination: str,
+        peo_in: Optional[str],
+        inc_in: Optional[str],
     ) -> None:
         """
         Searches the SEC website for filings based on the given parameters.
@@ -417,6 +441,8 @@ class EdgarTextSearcher:
         :param max_wait_seconds: Maximum number of seconds to wait for the request to complete
         :param retries: Number of times to retry the request before failing
         :param destination: Name of the CSV file to write the results to
+        :param peo_in: Search principal executive offices in a location (e.g. "NY,OH")
+        :param inc_in: Search incorporated in a location (e.g. "NY,OH")
         """
 
         self._generate_search_requests(
@@ -429,6 +455,8 @@ class EdgarTextSearcher:
             min_wait_seconds=min_wait_seconds,
             max_wait_seconds=max_wait_seconds,
             retries=retries,
+            peo_in=peo_in,
+            inc_in=inc_in,
         )
 
         search_requests_results: List[Iterator[Iterator[Dict[str, Any]]]] = []

--- a/edgar_tool/utils.py
+++ b/edgar_tool/utils.py
@@ -46,7 +46,8 @@ def replace_substrings_in_string(s):
     """
     Takes a string like "New York, OH" and returns a string with the full 
     location names converted to codes such as "NY, OH". Returns an unmodified 
-    string if there are no location names present. 
+    string if there are no location names present. Note that white strings are
+    removed and all letters are converted to lowercase to avoid unwanted string mismatches. 
 
     Parameters:
     s (str): The original string.
@@ -55,12 +56,12 @@ def replace_substrings_in_string(s):
     str: The modified string with substrings replaced.
     """
     locations2codes = invert_dict(TEXT_SEARCH_LOCATIONS_MAPPING)
-    locations2codes = {k.replace(" ", ""): v for k, v in locations2codes.items()}
-    s = s.replace(" ", "")
+    locations2codes = {k.replace(" ", "").lower(): v for k, v in locations2codes.items()}
+    s = s.replace(" ", "").lower()
     for location in locations2codes.keys():
         if location in s:
             s = s.replace(location, locations2codes[location])
-    return s
+    return s.upper()
     
 
 def parse_location_input(location_input: str | tuple | None) -> str | None:

--- a/edgar_tool/utils.py
+++ b/edgar_tool/utils.py
@@ -41,10 +41,13 @@ def parse_location_input(location_input: str | tuple | None) -> str | None:
     Handles text search input for --peo_in or --inc_in.
 
     This function processes the input to ensure it is in an acceptable format 
-    for location searches. It supports single or multiple locations provided 
-    as a string or a tuple. If the input is a tuple, it converts the tuple to 
-    a comma-separated string. It also removes any whitespace from the output 
-    string to prevent errors during further processing.
+    for location searches. Because CLI input like --peo_in "NY, OH" yields
+    python value ('NY','OH'), this function supports single or multiple locations 
+    provided as a string or a tuple. If the input is a tuple, it converts the tuple 
+    to a comma-separated string. It also removes any whitespace from the output 
+    string to prevent errors during further processing. Also validates that all
+    provided location codes are in the TEXT_SEARCH_LOCATIONS_MAPPING and prints
+    the list of acceptable codes if not.
 
     Parameters:
     location_input (str | tuple | None): The input location(s) to be parsed. 

--- a/edgar_tool/utils.py
+++ b/edgar_tool/utils.py
@@ -63,9 +63,9 @@ def replace_ignore_case_whitespace(s, location, replacement):
 def replace_substrings_in_string(s)->str:
     """
     Takes a string like "New York, OH" and returns a string with the full 
-    location names converted to codes such as "NY, OH". Returns an unmodified, but uppercase,
-    string if there are no location names present. Note that white spaces are
-    removed and matches are not case sensitive. 
+    location names converted to codes such as "NY,OH". Returns an unmodified
+    string if there are no full location names present. Note that matching
+    full location names shall be case and whitespace insensitive.
 
     Parameters:
     s (str): The original string.
@@ -78,8 +78,7 @@ def replace_substrings_in_string(s)->str:
     for location in locations2codes.keys():
         if location in s.replace(" ", "").lower():
             s = replace_ignore_case_whitespace(s,location, locations2codes[location])
-    ## Eliminate issues caused by casing and whitespaces
-    return s.replace(" ","").upper()
+    return s
     
 def parse_location_input(location_input: str | tuple | None) -> str | None:
     """
@@ -120,6 +119,8 @@ def parse_location_input(location_input: str | tuple | None) -> str | None:
     if isinstance(location_input,str):
         location_input = tuple(replace_substrings_in_string(location_input).split(','))
         for value in location_input:
+            # Eliminate issues caused by casing and whitespaces
+            value = value.replace(" ","").upper()
             if value not in TEXT_SEARCH_LOCATIONS_MAPPING.keys():
                 raise ValueError(f"{value} not in {TEXT_SEARCH_LOCATIONS_MAPPING}")
         location_input = ','.join(location_input)

--- a/edgar_tool/utils.py
+++ b/edgar_tool/utils.py
@@ -1,6 +1,6 @@
 from datetime import date
 from typing import Any, Iterator, Dict, List, Union, Optional
-
+from edgar_tool.constants import TEXT_SEARCH_LOCATIONS_MAPPING
 
 def split_date_range_in_n(start: date, end: date, n: int) -> Iterator[date]:
     """
@@ -35,3 +35,43 @@ def safe_get(d: Dict, *keys) -> Any:
 
 def unpack_singleton_list(l: Optional[List]) -> Union[str, List[str]]:
     return l if (l is None) or (len(l) != 1) else l[0]
+
+def parse_location_input(location_input: str | tuple | None) -> str:
+    """
+    Handles text search input for --peo_in or --inc_in.
+    
+    If the input is a full location name, it converts it to its corresponding code 
+    (e.g., "Sierra Leone" => "T8"). If the input is multiple locations, it converts 
+    the tuple to a string representation of a list. This function removes whitespace 
+    from the output string, which can cause additional locations to be ignored. It raises 
+    a ValueError if the locations are not of the accepted types.
+    """
+    
+    if not isinstance(location_input, (str, tuple, type(None))):
+        raise ValueError(
+            f'peo_in and inc_in must use format like "NY" or "NY,OH,etc" '
+            f'and be one of {list(TEXT_SEARCH_LOCATIONS_MAPPING.keys())}'
+        )
+
+    name2code = {value: key for key, value in TEXT_SEARCH_LOCATIONS_MAPPING.items()}
+
+    if isinstance(location_input, tuple):
+        location_input = tuple(
+            name2code.get(value, value)  
+            for value in location_input
+        )
+        for value in location_input:
+            if value not in TEXT_SEARCH_LOCATIONS_MAPPING:
+                raise ValueError(f"{value} not in {list(TEXT_SEARCH_LOCATIONS_MAPPING.keys())}")
+        location_input = ','.join(location_input)
+        
+    elif isinstance(location_input, str):
+        if location_input in TEXT_SEARCH_LOCATIONS_MAPPING.values():
+            location_input = name2code[location_input]
+        elif location_input not in TEXT_SEARCH_LOCATIONS_MAPPING.keys():
+            raise ValueError(f"{location_input} not in {list(TEXT_SEARCH_LOCATIONS_MAPPING.keys())}")
+
+    if location_input:
+        location_input = location_input.replace(" ","")
+        
+    return location_input

--- a/edgar_tool/utils.py
+++ b/edgar_tool/utils.py
@@ -36,42 +36,46 @@ def safe_get(d: Dict, *keys) -> Any:
 def unpack_singleton_list(l: Optional[List]) -> Union[str, List[str]]:
     return l if (l is None) or (len(l) != 1) else l[0]
 
-def parse_location_input(location_input: str | tuple | None) -> str:
+def parse_location_input(location_input: str | tuple | None) -> str | None:
     """
     Handles text search input for --peo_in or --inc_in.
-    
-    If the input is a full location name, it converts it to its corresponding code 
-    (e.g., "Sierra Leone" => "T8"). If the input is multiple locations, it converts 
-    the tuple to a string representation of a list. This function removes whitespace 
-    from the output string, which can cause additional locations to be ignored. It raises 
-    a ValueError if the locations are not of the accepted types.
+
+    This function processes the input to ensure it is in an acceptable format 
+    for location searches. It supports single or multiple locations provided 
+    as a string or a tuple. If the input is a tuple, it converts the tuple to 
+    a comma-separated string. It also removes any whitespace from the output 
+    string to prevent errors during further processing.
+
+    Parameters:
+    location_input (str | tuple | None): The input location(s) to be parsed. 
+        It can be a single location as a string, multiple locations as a tuple 
+        of strings, or None.
+
+    Returns:
+    str: A string representation of the location(s) with no whitespace.
+
+    Raises:
+    ValueError: If the input is not a string, tuple, or None, or if any location 
+        in the input is not in the TEXT_SEARCH_LOCATIONS_MAPPING.
     """
-    
+
     if not isinstance(location_input, (str, tuple, type(None))):
         raise ValueError(
             f'peo_in and inc_in must use format like "NY" or "NY,OH,etc" '
-            f'and be one of {list(TEXT_SEARCH_LOCATIONS_MAPPING.keys())}'
+            f'and be one of {TEXT_SEARCH_LOCATIONS_MAPPING}'
         )
-
-    name2code = {value: key for key, value in TEXT_SEARCH_LOCATIONS_MAPPING.items()}
 
     if isinstance(location_input, tuple):
-        location_input = tuple(
-            name2code.get(value, value)  
-            for value in location_input
-        )
         for value in location_input:
             if value not in TEXT_SEARCH_LOCATIONS_MAPPING:
-                raise ValueError(f"{value} not in {list(TEXT_SEARCH_LOCATIONS_MAPPING.keys())}")
+                raise ValueError(f"{value} not in {TEXT_SEARCH_LOCATIONS_MAPPING}")
         location_input = ','.join(location_input)
-        
+
     elif isinstance(location_input, str):
-        if location_input in TEXT_SEARCH_LOCATIONS_MAPPING.values():
-            location_input = name2code[location_input]
-        elif location_input not in TEXT_SEARCH_LOCATIONS_MAPPING.keys():
-            raise ValueError(f"{location_input} not in {list(TEXT_SEARCH_LOCATIONS_MAPPING.keys())}")
+        if location_input not in TEXT_SEARCH_LOCATIONS_MAPPING:
+            raise ValueError(f"{location_input} not in {TEXT_SEARCH_LOCATIONS_MAPPING}")
 
     if location_input:
-        location_input = location_input.replace(" ","")
-        
+        location_input = location_input.replace(" ", "")
+
     return location_input

--- a/edgar_tool/utils.py
+++ b/edgar_tool/utils.py
@@ -32,9 +32,36 @@ def safe_get(d: Dict, *keys) -> Any:
             return None
     return d
 
-
 def unpack_singleton_list(l: Optional[List]) -> Union[str, List[str]]:
     return l if (l is None) or (len(l) != 1) else l[0]
+
+def invert_dict(d:dict)->dict:
+    """
+        Returns an inverted dictionary such that values are keys and keys are values.
+        If there are duplicate values, the last occurring key-value pair will prevail. 
+    """
+    return {v: k for k, v in d.items()}
+
+def replace_substrings_in_string(s):
+    """
+    Takes a string like "New York, OH" and returns a string with the full 
+    location names converted to codes such as "NY, OH". Returns an unmodified 
+    string if there are no location names present. 
+
+    Parameters:
+    s (str): The original string.
+
+    Returns:
+    str: The modified string with substrings replaced.
+    """
+    locations2codes = invert_dict(TEXT_SEARCH_LOCATIONS_MAPPING)
+    locations2codes = {k.replace(" ", ""): v for k, v in locations2codes.items()}
+    s = s.replace(" ", "")
+    for location in locations2codes.keys():
+        if location in s:
+            s = s.replace(location, locations2codes[location])
+    return s
+    
 
 def parse_location_input(location_input: str | tuple | None) -> str | None:
     """
@@ -42,12 +69,14 @@ def parse_location_input(location_input: str | tuple | None) -> str | None:
 
     This function processes the input to ensure it is in an acceptable format 
     for location searches. Because CLI input like --peo_in "NY, OH" yields
-    python value ('NY','OH'), this function supports single or multiple locations 
+    runtime value ('NY','OH'), this function supports single or multiple locations 
     provided as a string or a tuple. If the input is a tuple, it converts the tuple 
     to a comma-separated string. It also removes any whitespace from the output 
     string to prevent errors during further processing. Also validates that all
     provided location codes are in the TEXT_SEARCH_LOCATIONS_MAPPING and prints
-    the list of acceptable codes if not.
+    the list of acceptable codes if not. If the input string is a location's full name
+    instead of the code (i.e. 'New York' instead of 'NY'), then strings present in
+    TEXT_SEARCH_LOCATIONS_MAPPING.values() are mapped to an code value instead. 
 
     Parameters:
     location_input (str | tuple | None): The input location(s) to be parsed. 
@@ -64,21 +93,21 @@ def parse_location_input(location_input: str | tuple | None) -> str | None:
 
     if not isinstance(location_input, (str, tuple, type(None))):
         raise ValueError(
-            f'peo_in and inc_in must use format like "NY" or "NY,OH,etc" '
+            f'peo_in and inc_in must use format like "NY" or "NY,OH,etc"'
             f'and be one of {TEXT_SEARCH_LOCATIONS_MAPPING}'
         )
-
-    if isinstance(location_input, tuple):
+    if isinstance(location_input,tuple):
+        location_input = ','.join(location_input)
+    
+    if isinstance(location_input,str):
+        ## regardless of input format, convert to tup because --peo_in "New York, OH" is interpreted as a string
+        location_input = tuple(replace_substrings_in_string(location_input).split(','))
         for value in location_input:
-            if value not in TEXT_SEARCH_LOCATIONS_MAPPING:
+            if value not in TEXT_SEARCH_LOCATIONS_MAPPING and value not in TEXT_SEARCH_LOCATIONS_MAPPING.values():
                 raise ValueError(f"{value} not in {TEXT_SEARCH_LOCATIONS_MAPPING}")
         location_input = ','.join(location_input)
 
-    elif isinstance(location_input, str):
-        if location_input not in TEXT_SEARCH_LOCATIONS_MAPPING:
-            raise ValueError(f"{location_input} not in {TEXT_SEARCH_LOCATIONS_MAPPING}")
-
     if location_input:
         location_input = location_input.replace(" ", "")
-
+        
     return location_input


### PR DESCRIPTION
Closes Issue #22  

edgar-tool now supports parameters ```inc_in``` for 'incorporated_in' and ```peo_in``` for 'principal executive offices in.'

both parameters takes a string like "NY" or "NY, OH." Any country code in ```edgar_tool.constants.TEXT_SEARCH_LOCATIONS_MAPPING``` is supported. 

Also, the country names as per TEXT_SEARCH_LOCATIONS_MAPPING.values() are accepted. Whitespace and upper/lower casing should be ignored, and so therefore, "mexico,ny" and "MexicO, Ny" will both convert to "NY,O5" 

Malformed input will result in the dictionary for ```edgar_tool.constants.TEXT_SEARCH_LOCATIONS_MAPPING``` being printed in the console so the user can see what codes they can use. 

I tested the following commands for both correct, incorrect, and unrelated use cases, I have pasted the results of that run in the attached file.  

```
$ poetry run edgar-tool text_search Tsunami Hazards --start_date "2019-06-01" --end_date "2024-01-01" --output "results.csv" --peo_in "NY, OH"
$ poetry run edgar-tool text_search Tsunami Hazards --start_date "2019-06-01" --end_date "2024-01-01" --output "results.csv" --peo_in "NY"
$ poetry run edgar-tool text_search Tsunami Hazards --start_date "2019-06-01" --end_date "2024-01-01" --output "results.csv" --inc_in "NY, OH, O5"
$ poetry run edgar-tool text_search Tsunami Hazards --start_date "2019-06-01" --end_date "2024-01-01" --output "results.csv" --inc_in "NY"
$ poetry run poetry run edgar-tool text_search Tsunami Hazards --start_date "2019-06-01" --end_date "2024-01-01" --output "results.csv" --peo_in "NY, Korea, Democratic People's Republic of, OH, Mexico"
$ poetry run poetry run edgar-tool text_search Tsunami Hazards --start_date "2019-06-01" --end_date "2024-01-01" --output "results.csv" --inc_in "Korea, Democratic People's Republic of"
$ poetry run edgar-tool text_search Tsunami Hazards --output "results.csv" --inc_in "Mexico"
$ poetry run poetry run edgar-tool text_search Tsunami Hazards --start_date "2019-06-01" --end_date "2024-01-01" --output "results.csv" --peo_in "mexico"
$ poetry run poetry run edgar-tool text_search Tsunami Hazards --start_date "2019-06-01" --end_date "2024-01-01" --output "results.csv" --inc_in "kOrEa, demOcratic people's republic of, OH"
$ poetry run edgar-tool text_search Tsunami Hazards --output "results.csv" --peo_in "hello world"
$ poetry run edgar-tool text_search Tsunami Hazards --output "results.csv" --inc_in 123
$ poetry run edgar-tool text_search Tsunami Hazards --start_date "2019-06-01" --end_date "2024-01-01" --output "results.csv" --inc_in "NY" --peo_in "NY, OH"
$ poetry run edgar-tool text_search Tsunami Hazards --start_date "2019-06-01" --end_date "2024-01-01" --output "results.csv"
```

[test cli session.txt](https://github.com/user-attachments/files/15748397/test.cli.session.txt)
