### PR TITLE
fix: trimmed cik

### DIFF
--- a/edgar_tool/text_search.py
+++ b/edgar_tool/text_search.py
@@ -79,7 +79,7 @@ class EdgarTextSearcher:
 
         # Fetching and cleaning CIKs
         ciks = _source.get("ciks")
-        ciks_trimmed: List[str] = [c.strip("0") for c in ciks]
+        ciks_trimmed: List[str] = [c.lstrip("0") for c in ciks]
 
         # Get form and human readable name
         root_form = _source.get("root_form")


### PR DESCRIPTION
The trimmed cik should only remove zeros from the left, otherwise the links won't work. See for example (note `177417` vs `1774170`)

master:
```
,,2023-05-26,,"PowerFleet, Inc.",AIOT,0001774170,177417,"Woodcliff Lake, New Jersey",Delaware,001-39080,23968803,https://www.sec.gov/cgi-bin/browse-edgar/?filenum=001-39080&action=getcompany,https://www.sec.gov/Archives/edgar/data/177417/000149315223019265/0001493152-23-019265-index.html,https://www.sec.gov/Archives/edgar/data/177417/000149315223019265/ex1-01.htm
```

fix:
```
,,2023-05-26,,"PowerFleet, Inc.",AIOT,0001774170,1774170,"Woodcliff Lake, New Jersey",Delaware,001-39080,23968803,https://www.sec.gov/cgi-bin/browse-edgar/?filenum=001-39080&action=getcompany,https://www.sec.gov/Archives/edgar/data/1774170/000149315223019265/0001493152-23-019265-index.html,https://www.sec.gov/Archives/edgar/data/1774170/000149315223019265/ex1-01.htm
```