### PR TITLE
build: Add Python 3.13 to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,16 +8,18 @@ RUN apt-get update && apt-get install -y \
     python3.9 python3.9-dev python3.9-venv \
     python3.10 python3.10-dev python3.10-venv \
     python3.11 python3.11-dev python3.11-venv \
-    python3.12 python3.12-dev python3.12-venv curl
+    python3.12 python3.12-dev python3.12-venv \
+    python3.13 python3.13-dev python3.13-venv \
+    curl
 
 # This installs pip for the primary version of Python we'll use
 # for development
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.13
 
 # Set default python executable for when users run python or python3
 # on the command line
-RUN ln -sf /usr/bin/python3.12 /usr/bin/python
-RUN ln -sf /usr/bin/python3.12 /usr/bin/python3
+RUN ln -sf /usr/bin/python3.13 /usr/bin/python
+RUN ln -sf /usr/bin/python3.13 /usr/bin/python3
 
 # Install pipx, poetry, and tox
 RUN python -m pip install --upgrade pip \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,14 +6,15 @@
     "customizations": {
         "vscode": {
             "settings": {
-                "python.defaultInterpreterPath": "/usr/bin/python3.12"
+                "python.defaultInterpreterPath": "/usr/bin/python3.13"
             },
             "extensions": [
-                "ms-python.python",
-                "ms-python.vscode-pylance",
-                "ms-python.debugpy",
+                "mechatroner.rainbow-csv",
                 "ms-azuretools.vscode-docker",
-                "mechatroner.rainbow-csv"
+                "ms-python.black-formatter",
+                "ms-python.debugpy",
+                "ms-python.python",
+                "ms-python.vscode-pylance"
             ]
         }
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Office/Business :: Financial",
 ]
 keywords=["scraper", "edgar", "finance", "sec"]


### PR DESCRIPTION
This PR adds Python 3.13 to the devcontainer's Dockerfile. It also adds Python 3.13 to the list of supported Python versions in pyproject.toml.