### PR TITLE
Bump micro version (2.1.0->2.1.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "edgar-tool"
-version = "2.1.0"
+version = "2.1.1"
 description = "Search and retrieve corporate and financial data from the United States Securities and Exchange Commission (SEC)."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Updates the micro version which contains an small update that removes a print statement when no results are found in a search.